### PR TITLE
Fixed nls_sig_convert_coef

### DIFF
--- a/R/fitplc.R
+++ b/R/fitplc.R
@@ -465,7 +465,7 @@ nls_sigmoidal_fixed <- function(Data, W, x, coverage,
     
     a <- coefs[1]
     b <- coefs[2]
-    Px <- ab_to_px(a, b, 100 - x)
+    Px <- ab_to_px(a, b, x)
     
     Sx <- 100 * sig2d(Px,a,b)
     


### PR DESCRIPTION
The x value seems to be just x instead of 100 - x  in `nls_sigmoidal_fixed` in `fitplc` according to https://github.com/RemkoDuursma/fitplc/blob/aabfe69fadb9a2236bc9400da299a7e55a948358/R/utils.R#L9 and https://github.com/RemkoDuursma/fitplc/blob/aabfe69fadb9a2236bc9400da299a7e55a948358/R/fitplc.R#L479-L480